### PR TITLE
Shell: added test #4 for Split_Left_String function

### DIFF
--- a/Shell/tests/String/Split_Left_String/3.ps1
+++ b/Shell/tests/String/Split_Left_String/3.ps1
@@ -1,0 +1,118 @@
+# Copyright 2024 (Holloway) Chew, Kean Ho <hello@hollowaykeanho.com>
+#
+#
+# Licensed under (Holloway) Chew, Kean Ho’s Liberal License (the "License").
+# You must comply with the license to use the content. Get the License at:
+#
+#                 https://doi.org/10.5281/zenodo.13770769
+#
+# You MUST ensure any interaction with the content STRICTLY COMPLIES with
+# the permissions and limitations set forth in the license.
+$null = Write-Host @"
+TEST CASE  :
+HestiaKERNEL_Split_String
+
+DESCRIPTION:
+Function can split an empty string.
+
+"@
+
+
+
+
+$null = Write-Host "Checking LIBS_HESTIA pathing: (${env:LIBS_HESTIA})"
+if (${env:LIBS_HESTIA} -eq "") {
+        $null = Write-Host "[ FAILED ] variable undefined!`n"
+        exit ${env:TEST_FAILED}
+}
+
+
+
+
+$___target = "${env:LIBS_HESTIA}\HestiaKERNEL\String\Split_Left_String.ps1"
+$null = Write-Host "Checking Library file (${___target})..."
+if (-not (Test-Path -Path $___target)) {
+        $null = Write-Host "[ FAILED ] missing file!`n"
+        exit ${env:TEST_FAILED}
+}
+
+
+
+
+$null = Write-Host "Import function library..."
+$null = . $___target
+if (-not (Get-Command 'HestiaKERNEL-Split-Left-String' -errorAction SilentlyContinue)) {
+        $null = Write-Host "[ FAILED ] error on import!`n"
+        exit ${env:TEST_FAILED}
+}
+
+
+
+
+$___input = ""
+$___target = "a"
+$___expect = @()
+$___expect_fallback = @()
+$___output = HestiaKERNEL-Split-Left-String $___input $___target
+
+$null = Write-Host "Given input :`n|${___input}|`n"
+$null = Write-Host "Given target:`n|${___target}|`n"
+
+$___verdict = 0
+if ($___output.Length -ne $___expect.Length) {
+} else {
+        for ($i = 0; $i -lt $___output.Length; $i++) {
+        }
+}
+
+$___length = $___output.Length
+if ($___expect.Length -gt $___length) {
+        $___length = $___expect.Length
+        $___verdict = 1
+}
+
+if ($___expect_fallback.Length -gt $___length) {
+        $___length = $___expect_fallback.Length
+        $___verdict = 1
+}
+
+$null = Write-Host "Got         :`n|index|expect|expect_fallback|output|"
+for ($i = 0; $i -lt $___length; $i++) {
+        try {
+                $___char_output = $___output[$i]
+        } catch {
+                $___char_output = ""
+        }
+
+        try {
+                $___char_expect = $___expect[$i]
+        } catch {
+                $___char_expect = ""
+        }
+
+        try {
+                $___char_expect_fallback = $___expect_fallback[$i]
+        } catch {
+                $___char_expect_fallback = ""
+        }
+
+        if (
+                ($___char_output -ne $___char_expect) -and
+                ($___char_output -ne $___char_expect_fallback)
+        ) {
+                $___verdict = 1
+        }
+
+        $null = Write-Host "|${i}|${___char_expect}|${___char_expect_fallback}|${___char_output}|"
+}
+
+
+
+
+# assert result
+if ($___verdict -eq 0) {
+        $null = Write-Host "[ PASSED ]"
+        exit ${env:TEST_PASSED}
+}
+$null = Write-Host "[ FAILED ] unexpected/inconsistent output!"
+exit ${env:TEST_FAILED}

--- a/Shell/tests/String/Split_Left_String/3.sh
+++ b/Shell/tests/String/Split_Left_String/3.sh
@@ -1,0 +1,77 @@
+#!/bin/sh
+# Copyright 2024 (Holloway) Chew, Kean Ho <hello@hollowaykeanho.com>
+#
+#
+# Licensed under (Holloway) Chew, Kean Ho’s Liberal License (the "License").
+# You must comply with the license to use the content. Get the License at:
+#
+#                 https://doi.org/10.5281/zenodo.13770769
+#
+# You MUST ensure any interaction with the content STRICTLY COMPLIES with
+# the permissions and limitations set forth in the license.
+Logf "%s\n" "\
+TEST CASE  :
+HestiaKERNEL_Split_String
+
+DESCRIPTION:
+Function can split an empty string.
+"
+
+
+
+
+Logf "Checking LIBS_HESTIA pathing: (%s)\n" "$LIBS_HESTIA"
+if [ "$LIBS_HESTIA" = "" ]; then
+        Logf "[ FAILED ] variable undefined!\n"
+        exit $TEST_FAILED
+fi
+
+
+
+
+___target="${LIBS_HESTIA}/HestiaKERNEL/String/Split_Left_String.sh"
+Logf "Checking Library file (%s)\n" "$___target"
+if [ ! -f "$___target" ]; then
+        Logf "[ FAILED ] missing file!\n"
+        exit $TEST_FAILED
+fi
+
+
+
+
+Logf "Import function library...\n"
+. "$___target"
+if [ $? -ne 0 ]; then
+        Logf "[ FAILED ] error on import!\n"
+        exit $TEST_FAILED
+fi
+
+
+
+
+___input=""
+___target="a"
+___expect=""
+___expect_fallback=""
+___output="$(HestiaKERNEL_Split_Left_String "$___input" "$___target")"
+___process=$?
+Logf "Given sample           :\n|%s|\n\n" "$___input"
+Logf "Given target           :\n|%s|\n\n" "$___target"
+Logf "Given expect           :\n|%s|\n\n" "$___expect"
+Logf "Given expect (fallback):\n|%s|\n\n" "$___expect_fallback"
+Logf "Given output           :\n|%s|\n\n" "$___output"
+if [ $___process -ne 0 ]; then
+        Logf "[ FAILED ] error on execution!\n"
+        exit $TEST_FAILED
+fi
+
+
+
+
+# assert result
+if [ "$___output" = "$___expect" ] || [ "$___output" = "$___expect_fallback" ]; then
+        Logf "[ PASSED ]\n"
+        exit $TEST_PASSED
+fi
+Logf "[ FAILED ] unexpected/inconsistent output!\n"
+exit $TEST_FAILED


### PR DESCRIPTION
There is a chance where an empty input stirng is provided for the said function to process. Hence, it must be able to handle it properly. Let's add its test case into the repository.

This patch adds test #4 for Split_Left_String function into Shell/ directory.