### PR TITLE
Shell: renamed all FS functions to align with new findings

### DIFF
--- a/Shell/libraries/HestiaKERNEL/FS/Get_Files.ps1
+++ b/Shell/libraries/HestiaKERNEL/FS/Get_Files.ps1
@@ -15,7 +15,7 @@
 
 
 
-function HestiaKERNEL-Get-Files-FS {
+function HestiaKERNEL-FS-Get-Files {
         param (
                 [string]$___directory,
                 [string]$___filter,
@@ -24,7 +24,7 @@ function HestiaKERNEL-Get-Files-FS {
 
 
         # validate input
-        if ($(HestiaKERNEL-Is-Directory-FS $___directory) -ne ${env:HestiaKERNEL_ERROR_OK}) {
+        if ($(HestiaKERNEL-FS-Is-Directory $___directory) -ne ${env:HestiaKERNEL_ERROR_OK}) {
                 return [string[]]@()
         }
 
@@ -32,15 +32,15 @@ function HestiaKERNEL-Get-Files-FS {
         # execute
         [System.Collections.Generic.List[string]]$___list = @()
         foreach ($____item in (Get-ChildItem $___directory)) {
-                if ($(HestiaKERNEL-Is-Directory-FS $____item) -eq ${env:HestiaKERNEL_ERROR_OK}) {
+                if ($(HestiaKERNEL-FS-Is-Directory $____item) -eq ${env:HestiaKERNEL_ERROR_OK}) {
                         if ($___recursive -eq 0) {
                                 continue
                         } elseif ($___recursive -gt 0) {
-                                $___results = HestiaKERNEL-Get-Files-FS $____item.FullName `
+                                $___results = HestiaKERNEL-FS-Get-Files $____item.FullName `
                                                                         $___filter `
                                                                         ($___recursive - 1)
                         } else {
-                                $___results = HestiaKERNEL-Get-Files-FS $____item.FullName `
+                                $___results = HestiaKERNEL-FS-Get-Files $____item.FullName `
                                                                         $___filter `
                                                                         -1
                         }
@@ -48,7 +48,7 @@ function HestiaKERNEL-Get-Files-FS {
                         foreach ($___result in $___results) {
                                 $___list.Add($___result)
                         }
-                } elseif ($(HestiaKERNEL-Is-File-FS $____item) -eq ${env:HestiaKERNEL_ERROR_OK}) {
+                } elseif ($(HestiaKERNEL-FS-Is-File $____item) -eq ${env:HestiaKERNEL_ERROR_OK}) {
                         if ($____item.Name -like "*${___filter}*") {
                                 $___list.Add($____item.FullName)
                         }

--- a/Shell/libraries/HestiaKERNEL/FS/Get_Files.sh
+++ b/Shell/libraries/HestiaKERNEL/FS/Get_Files.sh
@@ -17,14 +17,14 @@
 
 
 
-HestiaKERNEL_Get_Files_FS() {
+HestiaKERNEL_FS_Get_Files() {
         #___directory="$1"
         #___filter="$2"
         #___recursive="$3"
 
 
         # validate input
-        if [ $(HestiaKERNEL_Is_Directory_FS "$1") -ne $HestiaKERNEL_ERROR_OK ]; then
+        if [ $(HestiaKERNEL_FS_Is_Directory "$1") -ne $HestiaKERNEL_ERROR_OK ]; then
                 printf -- ""
                 return $HestiaKERNEL_ERROR_ENTITY_INVALID
         fi
@@ -32,7 +32,7 @@ HestiaKERNEL_Get_Files_FS() {
 
         # execute
         for ____item in "$1"/*; do
-                if [ $(HestiaKERNEL_Is_Directory_FS "$____item") -eq $HestiaKERNEL_ERROR_OK ]; then
+                if [ $(HestiaKERNEL_FS_Is_Directory "$____item") -eq $HestiaKERNEL_ERROR_OK ]; then
                         if [ $(HestiaKERNEL_Is_Number "$3") -ne $HestiaKERNEL_ERROR_OK ]; then
                                 continue
                         fi
@@ -40,11 +40,11 @@ HestiaKERNEL_Get_Files_FS() {
                         if [ $3 -eq 0 ]; then
                                 continue
                         elif [ $3 -gt 0 ]; then
-                                HestiaKERNEL_Get_Files_FS "$____item" "$2" "$(($3 - 1))"
+                                HestiaKERNEL_FS_Get_Files "$____item" "$2" "$(($3 - 1))"
                         else
-                                HestiaKERNEL_Get_Files_FS "$____item" "$2" "$3"
+                                HestiaKERNEL_FS_Get_Files "$____item" "$2" "$3"
                         fi
-                elif [ $(HestiaKERNEL_Is_File_FS "$____item") -eq $HestiaKERNEL_ERROR_OK ]; then
+                elif [ $(HestiaKERNEL_FS_Is_File "$____item") -eq $HestiaKERNEL_ERROR_OK ]; then
                         ____filename="${____item##*/}"
 
                         if [ "$2" = "" ]; then

--- a/Shell/libraries/HestiaKERNEL/FS/Is_Directory.ps1
+++ b/Shell/libraries/HestiaKERNEL/FS/Is_Directory.ps1
@@ -13,7 +13,7 @@
 
 
 
-function HestiaKERNEL-Is-Directory-FS {
+function HestiaKERNEL-FS-Is-Directory {
         param (
                 [string]$___target
         )

--- a/Shell/libraries/HestiaKERNEL/FS/Is_Directory.sh
+++ b/Shell/libraries/HestiaKERNEL/FS/Is_Directory.sh
@@ -14,7 +14,7 @@
 
 
 
-HestiaKERNEL_Is_Directory_FS() {
+HestiaKERNEL_FS_Is_Directory() {
         #___target="$1"
 
 

--- a/Shell/libraries/HestiaKERNEL/FS/Is_File.ps1
+++ b/Shell/libraries/HestiaKERNEL/FS/Is_File.ps1
@@ -13,7 +13,7 @@
 
 
 
-function HestiaKERNEL-Is-File-FS {
+function HestiaKERNEL-FS-Is-File {
         param (
                 [string]$___target
         )

--- a/Shell/libraries/HestiaKERNEL/FS/Is_File.sh
+++ b/Shell/libraries/HestiaKERNEL/FS/Is_File.sh
@@ -14,7 +14,7 @@
 
 
 
-HestiaKERNEL_Is_File_FS() {
+HestiaKERNEL_FS_Is_File() {
         #___target="$1"
 
 

--- a/Shell/shell/init.ps1
+++ b/Shell/shell/init.ps1
@@ -49,7 +49,7 @@ $null = New-Item -Path ${env:DIR_TEMP} -ItemType Directory -Force
 
 # source all init scripts if available
 if (Test-Path -Path "${env:DIR_WORKSPACE}\init" -PathType Container) {
-        foreach ($___script in $(Find-Files-Recursive "${env:DIR_WORKSPACE}\init" ".ps1")) {
+        foreach ($___script in $(HestiaKERNEL-FS-Get-Files "${env:DIR_WORKSPACE}\init" ".ps1")) {
                 $null = Write-Host "Sourcing ${___script} ..."
                 $___process = . $___script
                 if ($___process -ne 0) {

--- a/Shell/shell/init.sh
+++ b/Shell/shell/init.sh
@@ -25,7 +25,7 @@ export DIR_TEMP="${DIR_WORKSPACE}/temp"
 
 
 
-# setup locale
+# import required libraries
 ___old_IFS="$IFS"
 while IFS="" read -r ___line || [ -n "$___line" ]; do
         if [ ! -f "$___line" ]; then
@@ -52,7 +52,7 @@ mkdir -p "$DIR_TEMP"
 
 # source all init scripts if available
 if [ -d "${DIR_WORKSPACE}/init" ]; then
-        for ___script in $(HestiaKERNEL_Get_Files_FS "${DIR_WORKSPACE}/init" ".sh"); do
+        for ___script in $(HestiaKERNEL_FS_Get_Files "${DIR_WORKSPACE}/init" ".sh"); do
                 if [ ! -f "$___script" ]; then
                         continue
                 fi

--- a/Shell/shell/test.ps1
+++ b/Shell/shell/test.ps1
@@ -22,9 +22,20 @@ if ($___process -ne 0) {
 
 
 # import required libraries
-. "${env:LIBS_HESTIA}\HestiaKERNEL\FS\Get_Files.ps1"
-. "${env:LIBS_HESTIA}\HestiaKERNEL\Test\Codes.ps1"
-. "${env:LIBS_HESTIA}\HestiaKERNEL\Test\Exec_Test_Case.ps1"
+foreach ($___line in @(
+        "${env:DIR_WORKSPACE}\libraries\HestiaKERNEL\Unicode\Init.ps1",
+        "${env:DIR_WORKSPACE}\libraries\HestiaKERNEL\FS\Get_Files.ps1",
+        "${env:LIBS_HESTIA}\HestiaKERNEL\Test\Codes.ps1",
+        "${env:LIBS_HESTIA}\HestiaKERNEL\Test\Exec_Test_Case.ps1"
+)) {
+        $null = Write-Host "Importing '${___line}' ..."
+        if (-not (Test-Path $___line)) {
+                $null = Write-Host "[ ERROR ] Missing library."
+                return 1
+        }
+
+        $null = . $___line
+}
 
 
 
@@ -37,7 +48,7 @@ if (Test-Path -Path "${env:DIR_WORKSPACE}\tests" -PathType Container) {
         foreach (
                 $___script
                 in
-                $(HestiaKERNEL-Get-Files-FS "${env:DIR_WORKSPACE}\tests" ".ps1" -1)
+                $(HestiaKERNEL-FS-Get-Files "${env:DIR_WORKSPACE}\tests" ".ps1" -1)
         ) {
                 # increase total count
                 $___scripts_total += 1

--- a/Shell/shell/test.sh
+++ b/Shell/shell/test.sh
@@ -23,8 +23,22 @@ fi
 
 
 # import required libraries
-. "${LIBS_HESTIA}/HestiaKERNEL/Test/Codes.sh"
-. "${LIBS_HESTIA}/HestiaKERNEL/Test/Exec_Test_Case.sh"
+___old_IFS="$IFS"
+while IFS="" read -r ___line || [ -n "$___line" ]; do
+        1>&2 printf -- "Importing '${___line}' ...\n"
+        if [ ! -f "$___line" ]; then
+                1>&2 printf -- "[ ERROR ] Missing library.\n"
+                return 1
+        fi
+
+        . "$___line"
+done <<EOF
+${LIBS_HESTIA}/HestiaKERNEL/Unicode/Init.sh
+${LIBS_HESTIA}/HestiaKERNEL/FS/Get_Files.sh
+${LIBS_HESTIA}/HestiaKERNEL/Test/Codes.sh
+${LIBS_HESTIA}/HestiaKERNEL/Test/Exec_Test_Case.sh
+EOF
+IFS="$___old_IFS" && unset ___old_IFS
 
 
 
@@ -34,7 +48,7 @@ ___scripts_total=0
 ___scripts_passed=0
 ___only_failed="" # value: 'true' (string)
 if [ -d "${DIR_WORKSPACE}/tests" ]; then
-        for ___script in $(HestiaKERNEL_Get_Files_FS "${DIR_WORKSPACE}/tests" ".sh" "-1"); do
+        for ___script in $(HestiaKERNEL_FS_Get_Files "${DIR_WORKSPACE}/tests" ".sh" "-1"); do
                 # increase total count
                 ___scripts_total=$(($___scripts_total + 1))
 

--- a/Shell/tests/FS/Get_Files/0.ps1
+++ b/Shell/tests/FS/Get_Files/0.ps1
@@ -11,7 +11,7 @@
 # the permissions and limitations set forth in the license.
 $null = Write-Host @"
 TEST CASE  :
-HestiaKERNEL-Get-Files
+HestiaKERNEL-FS-Get-Files
 
 DESCRIPTION:
 Function can get all files.
@@ -42,7 +42,7 @@ if (-not (Test-Path -Path $___target)) {
 
 $null = Write-Host "Import function library..."
 $null = . $___target
-if (-not (Get-Command 'HestiaKERNEL-Get-Files-FS' -errorAction SilentlyContinue)) {
+if (-not (Get-Command 'HestiaKERNEL-FS-Get-Files' -errorAction SilentlyContinue)) {
         $null = Write-Host "[ FAILED ] error on import!`n"
         exit 1
 }
@@ -52,7 +52,7 @@ if (-not (Get-Command 'HestiaKERNEL-Get-Files-FS' -errorAction SilentlyContinue)
 
 $___input = "${env:LIBS_HESTIA}\HestiaKERNEL\FS"
 $___expect = ""
-$___output = HestiaKERNEL-Get-Files-FS $___input
+$___output = HestiaKERNEL-FS-Get-Files $___input
 $null = Write-Host "Given input        :`n|${___input}|`n"
 $null = Write-Host "Given expect       :`n|not empty|`n"
 $null = Write-Host "Got Output         :`n|${___output}|`n"

--- a/Shell/tests/FS/Get_Files/0.sh
+++ b/Shell/tests/FS/Get_Files/0.sh
@@ -11,7 +11,7 @@
 # the permissions and limitations set forth in the license.
 1>&2 printf --  "%s\n" "\
 TEST CASE  :
-HestiaKERNEL_Get_Files
+HestiaKERNEL_FS_Get_Files
 
 DESCRIPTION:
 Function can get all files.
@@ -41,7 +41,7 @@ fi
 
 1>&2 printf --  "Import function library...\n"
 . "$___target"
-___target="$(type HestiaKERNEL_Get_Files_FS)"
+___target="$(type HestiaKERNEL_FS_Get_Files)"
 if [ ! "${___target##*not found}"  = "$___target" ]; then
         1>&2 printf --  "[ FAILED ] error on import!\n"
         exit 1
@@ -56,7 +56,7 @@ ___input="${LIBS_HESTIA}/HestiaKERNEL/FS"
 ___expect=""
 1>&2 printf --  "Given expect           :\n|%s|\n\n" "not empty"
 
-___output="$(HestiaKERNEL_Get_Files_FS "$___input")"
+___output="$(HestiaKERNEL_FS_Get_Files "$___input")"
 ___process=$?
 1>&2 printf --  "Given output           :\n|%s|\n\n" "$___output"
 1>&2 printf --  "Given exit code        :\n|%s|\n\n" "$___process"

--- a/Shell/tests/FS/Get_Files/1.ps1
+++ b/Shell/tests/FS/Get_Files/1.ps1
@@ -11,7 +11,7 @@
 # the permissions and limitations set forth in the license.
 $null = Write-Host @"
 TEST CASE  :
-HestiaKERNEL-Get-Files
+HestiaKERNEL-FS-Get-Files
 
 DESCRIPTION:
 Function can get all files with specified filter.
@@ -42,7 +42,7 @@ if (-not (Test-Path -Path $___target)) {
 
 $null = Write-Host "Import function library..."
 $null = . $___target
-if (-not (Get-Command 'HestiaKERNEL-Get-Files-FS' -errorAction SilentlyContinue)) {
+if (-not (Get-Command 'HestiaKERNEL-FS-Get-Files' -errorAction SilentlyContinue)) {
         $null = Write-Host "[ FAILED ] error on import!`n"
         exit 1
 }
@@ -53,7 +53,7 @@ if (-not (Get-Command 'HestiaKERNEL-Get-Files-FS' -errorAction SilentlyContinue)
 $___input = "${env:LIBS_HESTIA}\HestiaKERNEL\FS"
 $___input_filter = ".ps1"
 $___expect = ""
-$___output = HestiaKERNEL-Get-Files-FS $___input $___input_filter
+$___output = HestiaKERNEL-FS-Get-Files $___input $___input_filter
 $null = Write-Host "Given input        :`n|${___input}|`n"
 $null = Write-Host "Given input filter :`n|${___input_filter}|`n"
 $null = Write-Host "Given expect       :`n|not empty|`n"

--- a/Shell/tests/FS/Get_Files/1.sh
+++ b/Shell/tests/FS/Get_Files/1.sh
@@ -11,7 +11,7 @@
 # the permissions and limitations set forth in the license.
 1>&2 printf --  "%s\n" "\
 TEST CASE  :
-HestiaKERNEL_Get_Files
+HestiaKERNEL_FS_Get_Files
 
 DESCRIPTION:
 Function can get all files with specified filter.
@@ -41,7 +41,7 @@ fi
 
 1>&2 printf --  "Import function library...\n"
 . "$___target"
-___target="$(type HestiaKERNEL_Get_Files_FS)"
+___target="$(type HestiaKERNEL_FS_Get_Files)"
 if [ ! "${___target##*not found}"  = "$___target" ]; then
         1>&2 printf --  "[ FAILED ] error on import!\n"
         exit 1
@@ -58,7 +58,7 @@ ___input_filter=".sh"
 ___expect=""
 1>&2 printf --  "Given expect           :\n|%s|\n\n" "not empty"
 
-___output="$(HestiaKERNEL_Get_Files_FS "$___input" "$___input_filter")"
+___output="$(HestiaKERNEL_FS_Get_Files "$___input" "$___input_filter")"
 ___process=$?
 1>&2 printf --  "Given output           :\n|%s|\n\n" "$___output"
 1>&2 printf --  "Given exit code        :\n|%s|\n\n" "$___process"

--- a/Shell/tests/FS/Get_Files/2.ps1
+++ b/Shell/tests/FS/Get_Files/2.ps1
@@ -11,7 +11,7 @@
 # the permissions and limitations set forth in the license.
 $null = Write-Host @"
 TEST CASE  :
-HestiaKERNEL-Get-Files
+HestiaKERNEL-FS-Get-Files
 
 DESCRIPTION:
 Function can get all files with specified filter recursively.
@@ -42,7 +42,7 @@ if (-not (Test-Path -Path $___target)) {
 
 $null = Write-Host "Import function library..."
 $null = . $___target
-if (-not (Get-Command 'HestiaKERNEL-Get-Files-FS' -errorAction SilentlyContinue)) {
+if (-not (Get-Command 'HestiaKERNEL-FS-Get-Files' -errorAction SilentlyContinue)) {
         $null = Write-Host "[ FAILED ] error on import!`n"
         exit 1
 }
@@ -54,7 +54,7 @@ $___input = ${env:LIBS_HESTIA}
 $___input_filter = ".ps1"
 $___input_recursive = -1
 $___expect = ""
-$___output = HestiaKERNEL-Get-Files-FS $___input $___input_filter $___input_recursive
+$___output = HestiaKERNEL-FS-Get-Files $___input $___input_filter $___input_recursive
 $null = Write-Host "Given input           :`n|${___input}|`n"
 $null = Write-Host "Given input filter    :`n|${___input_filter}|`n"
 $null = Write-Host "Given input recursive :`n|${___input_recursive}|`n"

--- a/Shell/tests/FS/Get_Files/2.sh
+++ b/Shell/tests/FS/Get_Files/2.sh
@@ -11,7 +11,7 @@
 # the permissions and limitations set forth in the license.
 1>&2 printf --  "%s\n" "\
 TEST CASE  :
-HestiaKERNEL_Get_Files
+HestiaKERNEL_FS_Get_Files
 
 DESCRIPTION:
 Function can get all files with specified filter recursively.
@@ -41,7 +41,7 @@ fi
 
 1>&2 printf --  "Import function library...\n"
 . "$___target"
-___target="$(type HestiaKERNEL_Get_Files_FS)"
+___target="$(type HestiaKERNEL_FS_Get_Files)"
 if [ ! "${___target##*not found}"  = "$___target" ]; then
         1>&2 printf --  "[ FAILED ] error on import!\n"
         exit 1
@@ -60,7 +60,7 @@ ___input_recursive="-1"
 ___expect=""
 1>&2 printf --  "Given expect           :\n|%s|\n\n" "not empty"
 
-___output="$(HestiaKERNEL_Get_Files_FS "$___input" "$___input_filter" "$___input_recursive")"
+___output="$(HestiaKERNEL_FS_Get_Files "$___input" "$___input_filter" "$___input_recursive")"
 ___process=$?
 1>&2 printf --  "Given output           :\n|%s|\n\n" "$___output"
 1>&2 printf --  "Given exit code        :\n|%s|\n\n" "$___process"

--- a/Shell/tests/FS/Get_Files/3.ps1
+++ b/Shell/tests/FS/Get_Files/3.ps1
@@ -11,7 +11,7 @@
 # the permissions and limitations set forth in the license.
 $null = Write-Host @"
 TEST CASE  :
-HestiaKERNEL-Get-Files
+HestiaKERNEL-FS-Get-Files
 
 DESCRIPTION:
 Function can get all files with specified filter and controlled recursively.
@@ -42,7 +42,7 @@ if (-not (Test-Path -Path $___target)) {
 
 $null = Write-Host "Import function library..."
 $null = . $___target
-if (-not (Get-Command 'HestiaKERNEL-Get-Files-FS' -errorAction SilentlyContinue)) {
+if (-not (Get-Command 'HestiaKERNEL-FS-Get-Files' -errorAction SilentlyContinue)) {
         $null = Write-Host "[ FAILED ] error on import!`n"
         exit 1
 }
@@ -54,7 +54,7 @@ $___input = ${env:LIBS_HESTIA}
 $___input_filter = ".ps1"
 $___input_recursive = 1
 $___expect = ""
-$___output = HestiaKERNEL-Get-Files-FS $___input $___input_filter $___input_recursive
+$___output = HestiaKERNEL-FS-Get-Files $___input $___input_filter $___input_recursive
 $null = Write-Host "Given input           :`n|${___input}|`n"
 $null = Write-Host "Given input filter    :`n|${___input_filter}|`n"
 $null = Write-Host "Given input recursive :`n|${___input_recursive}|`n"

--- a/Shell/tests/FS/Get_Files/3.sh
+++ b/Shell/tests/FS/Get_Files/3.sh
@@ -11,7 +11,7 @@
 # the permissions and limitations set forth in the license.
 1>&2 printf --  "%s\n" "\
 TEST CASE  :
-HestiaKERNEL_Get_Files
+HestiaKERNEL_FS_Get_Files
 
 DESCRIPTION:
 Function can get all files with specified filter and controlled recursively.
@@ -41,7 +41,7 @@ fi
 
 1>&2 printf --  "Import function library...\n"
 . "$___target"
-___target="$(type HestiaKERNEL_Get_Files_FS)"
+___target="$(type HestiaKERNEL_FS_Get_Files)"
 if [ ! "${___target##*not found}"  = "$___target" ]; then
         1>&2 printf --  "[ FAILED ] error on import!\n"
         exit 1
@@ -60,7 +60,7 @@ ___input_recursive="1"
 ___expect=""
 1>&2 printf --  "Given expect           :\n|%s|\n\n" "not empty"
 
-___output="$(HestiaKERNEL_Get_Files_FS "$___input" "$___input_filter" "$___input_recursive")"
+___output="$(HestiaKERNEL_FS_Get_Files "$___input" "$___input_filter" "$___input_recursive")"
 ___process=$?
 1>&2 printf --  "Given output           :\n|%s|\n\n" "$___output"
 1>&2 printf --  "Given exit code        :\n|%s|\n\n" "$___process"

--- a/Shell/tests/FS/Get_Files/4.ps1
+++ b/Shell/tests/FS/Get_Files/4.ps1
@@ -11,7 +11,7 @@
 # the permissions and limitations set forth in the license.
 $null = Write-Host @"
 TEST CASE  :
-HestiaKERNEL-Get-Files
+HestiaKERNEL-FS-Get-Files
 
 DESCRIPTION:
 Function can handle invalid path.
@@ -42,7 +42,7 @@ if (-not (Test-Path -Path $___target)) {
 
 $null = Write-Host "Import function library..."
 $null = . $___target
-if (-not (Get-Command 'HestiaKERNEL-Get-Files-FS' -errorAction SilentlyContinue)) {
+if (-not (Get-Command 'HestiaKERNEL-FS-Get-Files' -errorAction SilentlyContinue)) {
         $null = Write-Host "[ FAILED ] error on import!`n"
         exit 1
 }
@@ -52,7 +52,7 @@ if (-not (Get-Command 'HestiaKERNEL-Get-Files-FS' -errorAction SilentlyContinue)
 
 $___input = "${env:LIBS_HESTIA}\HestiaKERNEL\aebaebaebae"
 $___expect = ""
-$___output = HestiaKERNEL-Get-Files-FS $___input
+$___output = HestiaKERNEL-FS-Get-Files $___input
 $null = Write-Host "Given input        :`n|${___input}|`n"
 $null = Write-Host "Given expect       :`n|${___expect}|`n"
 $null = Write-Host "Got Output         :`n|${___output}|`n"

--- a/Shell/tests/FS/Get_Files/4.sh
+++ b/Shell/tests/FS/Get_Files/4.sh
@@ -11,7 +11,7 @@
 # the permissions and limitations set forth in the license.
 1>&2 printf --  "%s\n" "\
 TEST CASE  :
-HestiaKERNEL_Get_Files
+HestiaKERNEL_FS_Get_Files
 
 DESCRIPTION:
 Function can handle invalid path.
@@ -41,7 +41,7 @@ fi
 
 1>&2 printf --  "Import function library...\n"
 . "$___target"
-___target="$(type HestiaKERNEL_Get_Files_FS)"
+___target="$(type HestiaKERNEL_FS_Get_Files)"
 if [ ! "${___target##*not found}"  = "$___target" ]; then
         1>&2 printf --  "[ FAILED ] error on import!\n"
         exit 1
@@ -56,7 +56,7 @@ ___input="${LIBS_HESTIA}/HestiaKERNEL/aebaebaebae"
 ___expect=""
 1>&2 printf --  "Given expect           :\n|%s|\n\n" "empty"
 
-___output="$(HestiaKERNEL_Get_Files_FS "$___input")"
+___output="$(HestiaKERNEL_FS_Get_Files "$___input")"
 ___process=$?
 1>&2 printf --  "Given output           :\n|%s|\n\n" "$___output"
 1>&2 printf --  "Given exit code        :\n|%s|\n\n" "$___process"

--- a/Shell/tests/FS/Get_Files/5.ps1
+++ b/Shell/tests/FS/Get_Files/5.ps1
@@ -11,7 +11,7 @@
 # the permissions and limitations set forth in the license.
 $null = Write-Host @"
 TEST CASE  :
-HestiaKERNEL-Get-Files
+HestiaKERNEL-FS-Get-Files
 
 DESCRIPTION:
 Function can handle empty path.
@@ -42,7 +42,7 @@ if (-not (Test-Path -Path $___target)) {
 
 $null = Write-Host "Import function library..."
 $null = . $___target
-if (-not (Get-Command 'HestiaKERNEL-Get-Files-FS' -errorAction SilentlyContinue)) {
+if (-not (Get-Command 'HestiaKERNEL-FS-Get-Files' -errorAction SilentlyContinue)) {
         $null = Write-Host "[ FAILED ] error on import!`n"
         exit 1
 }
@@ -52,7 +52,7 @@ if (-not (Get-Command 'HestiaKERNEL-Get-Files-FS' -errorAction SilentlyContinue)
 
 $___input = ""
 $___expect = ""
-$___output = HestiaKERNEL-Get-Files-FS $___input
+$___output = HestiaKERNEL-FS-Get-Files $___input
 $null = Write-Host "Given input        :`n|${___input}|`n"
 $null = Write-Host "Given expect       :`n|not empty|`n"
 $null = Write-Host "Got Output         :`n|${___output}|`n"

--- a/Shell/tests/FS/Get_Files/5.sh
+++ b/Shell/tests/FS/Get_Files/5.sh
@@ -11,7 +11,7 @@
 # the permissions and limitations set forth in the license.
 1>&2 printf --  "%s\n" "\
 TEST CASE  :
-HestiaKERNEL_Get_Files
+HestiaKERNEL_FS_Get_Files
 
 DESCRIPTION:
 Function can handle empty path.
@@ -41,7 +41,7 @@ fi
 
 1>&2 printf --  "Import function library...\n"
 . "$___target"
-___target="$(type HestiaKERNEL_Get_Files_FS)"
+___target="$(type HestiaKERNEL_FS_Get_Files)"
 if [ ! "${___target##*not found}"  = "$___target" ]; then
         1>&2 printf --  "[ FAILED ] error on import!\n"
         exit 1
@@ -56,7 +56,7 @@ ___input=""
 ___expect=""
 1>&2 printf --  "Given expect           :\n|%s|\n\n" "empty"
 
-___output="$(HestiaKERNEL_Get_Files_FS "$___input")"
+___output="$(HestiaKERNEL_FS_Get_Files "$___input")"
 ___process=$?
 1>&2 printf --  "Given output           :\n|%s|\n\n" "$___output"
 1>&2 printf --  "Given exit code        :\n|%s|\n\n" "$___process"

--- a/Shell/tests/FS/Get_Files/6.ps1
+++ b/Shell/tests/FS/Get_Files/6.ps1
@@ -11,7 +11,7 @@
 # the permissions and limitations set forth in the license.
 $null = Write-Host @"
 TEST CASE  :
-HestiaKERNEL-Get-Files
+HestiaKERNEL-FS-Get-Files
 
 DESCRIPTION:
 Function can handle invalid path with specified filter and controlled
@@ -43,7 +43,7 @@ if (-not (Test-Path -Path $___target)) {
 
 $null = Write-Host "Import function library..."
 $null = . $___target
-if (-not (Get-Command 'HestiaKERNEL-Get-Files-FS' -errorAction SilentlyContinue)) {
+if (-not (Get-Command 'HestiaKERNEL-FS-Get-Files' -errorAction SilentlyContinue)) {
         $null = Write-Host "[ FAILED ] error on import!`n"
         exit 1
 }
@@ -55,7 +55,7 @@ $___input = "${env:LIBS_HESTIA}\HestiaKERNEL\aerrgbaerbaer"
 $___input_filter = ".ps1"
 $___input_recursive = 1
 $___expect = ""
-$___output = HestiaKERNEL-Get-Files-FS $___input $___input_filter $___input_recursive
+$___output = HestiaKERNEL-FS-Get-Files $___input $___input_filter $___input_recursive
 $null = Write-Host "Given input           :`n|${___input}|`n"
 $null = Write-Host "Given input filter    :`n|${___input_filter}|`n"
 $null = Write-Host "Given input recursive :`n|${___input_recursive}|`n"

--- a/Shell/tests/FS/Get_Files/6.sh
+++ b/Shell/tests/FS/Get_Files/6.sh
@@ -11,7 +11,7 @@
 # the permissions and limitations set forth in the license.
 1>&2 printf --  "%s\n" "\
 TEST CASE  :
-HestiaKERNEL_Get_Files
+HestiaKERNEL_FS_Get_Files
 
 DESCRIPTION:
 Function can handle invalid path with specified filter and controlled recursively.
@@ -41,7 +41,7 @@ fi
 
 1>&2 printf --  "Import function library...\n"
 . "$___target"
-___target="$(type HestiaKERNEL_Get_Files_FS)"
+___target="$(type HestiaKERNEL_FS_Get_Files)"
 if [ ! "${___target##*not found}"  = "$___target" ]; then
         1>&2 printf --  "[ FAILED ] error on import!\n"
         exit 1
@@ -60,7 +60,7 @@ ___input_recursive="1"
 ___expect=""
 1>&2 printf --  "Given expect           :\n|%s|\n\n" "not empty"
 
-___output="$(HestiaKERNEL_Get_Files_FS "$___input" "$___input_filter" "$___input_recursive")"
+___output="$(HestiaKERNEL_FS_Get_Files "$___input" "$___input_filter" "$___input_recursive")"
 ___process=$?
 1>&2 printf --  "Given output           :\n|%s|\n\n" "$___output"
 1>&2 printf --  "Given exit code        :\n|%s|\n\n" "$___process"

--- a/Shell/tests/FS/Get_Files/7.ps1
+++ b/Shell/tests/FS/Get_Files/7.ps1
@@ -11,7 +11,7 @@
 # the permissions and limitations set forth in the license.
 $null = Write-Host @"
 TEST CASE  :
-HestiaKERNEL-Get-Files
+HestiaKERNEL-FS-Get-Files
 
 DESCRIPTION:
 Function can handle empty path with specified filter and controlled recursively.
@@ -42,7 +42,7 @@ if (-not (Test-Path -Path $___target)) {
 
 $null = Write-Host "Import function library..."
 $null = . $___target
-if (-not (Get-Command 'HestiaKERNEL-Get-Files-FS' -errorAction SilentlyContinue)) {
+if (-not (Get-Command 'HestiaKERNEL-FS-Get-Files' -errorAction SilentlyContinue)) {
         $null = Write-Host "[ FAILED ] error on import!`n"
         exit 1
 }
@@ -54,7 +54,7 @@ $___input = ""
 $___input_filter = ".ps1"
 $___input_recursive = 1
 $___expect = ""
-$___output = HestiaKERNEL-Get-Files-FS $___input $___input_filter $___input_recursive
+$___output = HestiaKERNEL-FS-Get-Files $___input $___input_filter $___input_recursive
 $null = Write-Host "Given input           :`n|${___input}|`n"
 $null = Write-Host "Given input filter    :`n|${___input_filter}|`n"
 $null = Write-Host "Given input recursive :`n|${___input_recursive}|`n"

--- a/Shell/tests/FS/Get_Files/7.sh
+++ b/Shell/tests/FS/Get_Files/7.sh
@@ -11,7 +11,7 @@
 # the permissions and limitations set forth in the license.
 1>&2 printf --  "%s\n" "\
 TEST CASE  :
-HestiaKERNEL_Get_Files
+HestiaKERNEL_FS_Get_Files
 
 DESCRIPTION:
 Function can handle empty path with specified filter and controlled recursively.
@@ -41,7 +41,7 @@ fi
 
 1>&2 printf --  "Import function library...\n"
 . "$___target"
-___target="$(type HestiaKERNEL_Get_Files_FS)"
+___target="$(type HestiaKERNEL_FS_Get_Files)"
 if [ ! "${___target##*not found}"  = "$___target" ]; then
         1>&2 printf --  "[ FAILED ] error on import!\n"
         exit 1
@@ -60,7 +60,7 @@ ___input_recursive="1"
 ___expect=""
 1>&2 printf --  "Given expect           :\n|%s|\n\n" "not empty"
 
-___output="$(HestiaKERNEL_Get_Files_FS "$___input" "$___input_filter" "$___input_recursive")"
+___output="$(HestiaKERNEL_FS_Get_Files "$___input" "$___input_filter" "$___input_recursive")"
 ___process=$?
 1>&2 printf --  "Given output           :\n|%s|\n\n" "$___output"
 1>&2 printf --  "Given exit code        :\n|%s|\n\n" "$___process"

--- a/Shell/tests/FS/Get_Files/8.ps1
+++ b/Shell/tests/FS/Get_Files/8.ps1
@@ -11,7 +11,7 @@
 # the permissions and limitations set forth in the license.
 $null = Write-Host @"
 TEST CASE  :
-HestiaKERNEL-Get-Files
+HestiaKERNEL-FS-Get-Files
 
 DESCRIPTION:
 Function can handle file path with specified filter and controlled recursively.
@@ -42,7 +42,7 @@ if (-not (Test-Path -Path $___target)) {
 
 $null = Write-Host "Import function library..."
 $null = . $___target
-if (-not (Get-Command 'HestiaKERNEL-Get-Files-FS' -errorAction SilentlyContinue)) {
+if (-not (Get-Command 'HestiaKERNEL-FS-Get-Files' -errorAction SilentlyContinue)) {
         $null = Write-Host "[ FAILED ] error on import!`n"
         exit 1
 }
@@ -54,7 +54,7 @@ $___input = "${env:LIBS_HESTIA}\HestiaKERNEL\Vanilla.sh.ps1"
 $___input_filter = ".ps1"
 $___input_recursive = 1
 $___expect = ""
-$___output = HestiaKERNEL-Get-Files-FS $___input $___input_filter $___input_recursive
+$___output = HestiaKERNEL-FS-Get-Files $___input $___input_filter $___input_recursive
 $null = Write-Host "Given input           :`n|${___input}|`n"
 $null = Write-Host "Given input filter    :`n|${___input_filter}|`n"
 $null = Write-Host "Given input recursive :`n|${___input_recursive}|`n"

--- a/Shell/tests/FS/Get_Files/8.sh
+++ b/Shell/tests/FS/Get_Files/8.sh
@@ -11,7 +11,7 @@
 # the permissions and limitations set forth in the license.
 1>&2 printf --  "%s\n" "\
 TEST CASE  :
-HestiaKERNEL_Get_Files
+HestiaKERNEL_FS_Get_Files
 
 DESCRIPTION:
 Function can handle file path with specified filter and controlled recursively.
@@ -41,7 +41,7 @@ fi
 
 1>&2 printf --  "Import function library...\n"
 . "$___target"
-___target="$(type HestiaKERNEL_Get_Files_FS)"
+___target="$(type HestiaKERNEL_FS_Get_Files)"
 if [ ! "${___target##*not found}"  = "$___target" ]; then
         1>&2 printf --  "[ FAILED ] error on import!\n"
         exit 1
@@ -60,7 +60,7 @@ ___input_recursive="1"
 ___expect=""
 1>&2 printf --  "Given expect           :\n|%s|\n\n" "not empty"
 
-___output="$(HestiaKERNEL_Get_Files_FS "$___input" "$___input_filter" "$___input_recursive")"
+___output="$(HestiaKERNEL_FS_Get_Files "$___input" "$___input_filter" "$___input_recursive")"
 ___process=$?
 1>&2 printf --  "Given output           :\n|%s|\n\n" "$___output"
 1>&2 printf --  "Given exit code        :\n|%s|\n\n" "$___process"

--- a/Shell/tests/FS/Is_Directory/0.ps1
+++ b/Shell/tests/FS/Is_Directory/0.ps1
@@ -11,7 +11,7 @@
 # the permissions and limitations set forth in the license.
 $null = Write-Host @"
 TEST CASE  :
-HestiaKERNEL-Is-Directory
+HestiaKERNEL-FS-Is-Directory
 
 DESCRIPTION:
 Function can identify a proper directory path.
@@ -42,7 +42,7 @@ if (-not (Test-Path -Path $___target)) {
 
 $null = Write-Host "Import function library..."
 $null = . $___target
-if (-not (Get-Command 'HestiaKERNEL-Is-Directory-FS' -errorAction SilentlyContinue)) {
+if (-not (Get-Command 'HestiaKERNEL-FS-Is-Directory' -errorAction SilentlyContinue)) {
         $null = Write-Host "[ FAILED ] error on import!`n"
         exit 1
 }
@@ -52,7 +52,7 @@ if (-not (Get-Command 'HestiaKERNEL-Is-Directory-FS' -errorAction SilentlyContin
 
 $___input = "${env:LIBS_HESTIA}\HestiaKERNEL"
 $___expect = 0
-$___output = HestiaKERNEL-Is-Directory-FS $___input
+$___output = HestiaKERNEL-FS-Is-Directory $___input
 $null = Write-Host "Given input  :`n|${___input}|`n"
 $null = Write-Host "Given expect :`n|${___expect}|`n"
 $null = Write-Host "Got Output   :`n|${___output}|`n"

--- a/Shell/tests/FS/Is_Directory/0.sh
+++ b/Shell/tests/FS/Is_Directory/0.sh
@@ -11,7 +11,7 @@
 # the permissions and limitations set forth in the license.
 1>&2 printf --  "%s\n" "\
 TEST CASE  :
-HestiaKERNEL_Is_Directory
+HestiaKERNEL_FS_Is_Directory
 
 DESCRIPTION:
 Function can identify a proper directory path.
@@ -41,7 +41,7 @@ fi
 
 1>&2 printf --  "Import function library...\n"
 . "$___target"
-___target="$(type HestiaKERNEL_Is_Directory_FS)"
+___target="$(type HestiaKERNEL_FS_Is_Directory)"
 if [ ! "${___target##*not found}"  = "$___target" ]; then
         1>&2 printf --  "[ FAILED ] error on import!\n"
         exit 1
@@ -52,7 +52,7 @@ fi
 
 ___input="${LIBS_HESTIA}/HestiaKERNEL"
 ___expect="0"
-___output="$(HestiaKERNEL_Is_Directory_FS "$___input")"
+___output="$(HestiaKERNEL_FS_Is_Directory "$___input")"
 ___process=$?
 1>&2 printf --  "Given input            :\n|%s|\n\n" "$___input"
 1>&2 printf --  "Given expect           :\n|%s|\n\n" "$___expect"

--- a/Shell/tests/FS/Is_Directory/1.ps1
+++ b/Shell/tests/FS/Is_Directory/1.ps1
@@ -11,7 +11,7 @@
 # the permissions and limitations set forth in the license.
 $null = Write-Host @"
 TEST CASE  :
-HestiaKERNEL-Is-Directory
+HestiaKERNEL-FS-Is-Directory
 
 DESCRIPTION:
 Function can identify a proper file path.
@@ -42,7 +42,7 @@ if (-not (Test-Path -Path $___target)) {
 
 $null = Write-Host "Import function library..."
 $null = . $___target
-if (-not (Get-Command 'HestiaKERNEL-Is-Directory-FS' -errorAction SilentlyContinue)) {
+if (-not (Get-Command 'HestiaKERNEL-FS-Is-Directory' -errorAction SilentlyContinue)) {
         $null = Write-Host "[ FAILED ] error on import!`n"
         exit 1
 }
@@ -52,7 +52,7 @@ if (-not (Get-Command 'HestiaKERNEL-Is-Directory-FS' -errorAction SilentlyContin
 
 $___input = "${env:LIBS_HESTIA}\HestiaKERNEL\FS\Is_Directory.ps1"
 $___expect = 0
-$___output = HestiaKERNEL-Is-Directory-FS $___input
+$___output = HestiaKERNEL-FS-Is-Directory $___input
 $null = Write-Host "Given input  :`n|${___input}|`n"
 $null = Write-Host "Given expect :`n|not ${___expect}|`n"
 $null = Write-Host "Got Output   :`n|${___output}|`n"

--- a/Shell/tests/FS/Is_Directory/1.sh
+++ b/Shell/tests/FS/Is_Directory/1.sh
@@ -11,7 +11,7 @@
 # the permissions and limitations set forth in the license.
 1>&2 printf --  "%s\n" "\
 TEST CASE  :
-HestiaKERNEL_Is_Directory
+HestiaKERNEL_FS_Is_Directory
 
 DESCRIPTION:
 Function can identify a proper file path.
@@ -41,7 +41,7 @@ fi
 
 1>&2 printf --  "Import function library...\n"
 . "$___target"
-___target="$(type HestiaKERNEL_Is_Directory_FS)"
+___target="$(type HestiaKERNEL_FS_Is_Directory)"
 if [ ! "${___target##*not found}"  = "$___target" ]; then
         1>&2 printf --  "[ FAILED ] error on import!\n"
         exit 1
@@ -56,7 +56,7 @@ ___input="${LIBS_HESTIA}/HestiaKERNEL/FS/Is_Directory.sh"
 ___expect="0"
 1>&2 printf --  "Given expect           :\n|%s|\n\n" "not $___expect"
 
-___output="$(HestiaKERNEL_Is_Directory_FS "$___input")"
+___output="$(HestiaKERNEL_FS_Is_Directory "$___input")"
 ___process=$?
 1>&2 printf --  "Given output           :\n|%s|\n\n" "$___output"
 1>&2 printf --  "Given exit code        :\n|%s|\n\n" "$___process"

--- a/Shell/tests/FS/Is_Directory/2.ps1
+++ b/Shell/tests/FS/Is_Directory/2.ps1
@@ -11,7 +11,7 @@
 # the permissions and limitations set forth in the license.
 $null = Write-Host @"
 TEST CASE  :
-HestiaKERNEL-Is-Directory
+HestiaKERNEL-FS-Is-Directory
 
 DESCRIPTION:
 Function can operate with empty string.
@@ -42,7 +42,7 @@ if (-not (Test-Path -Path $___target)) {
 
 $null = Write-Host "Import function library..."
 $null = . $___target
-if (-not (Get-Command 'HestiaKERNEL-Is-Directory-FS' -errorAction SilentlyContinue)) {
+if (-not (Get-Command 'HestiaKERNEL-FS-Is-Directory' -errorAction SilentlyContinue)) {
         $null = Write-Host "[ FAILED ] error on import!`n"
         exit 1
 }
@@ -52,9 +52,9 @@ if (-not (Get-Command 'HestiaKERNEL-Is-Directory-FS' -errorAction SilentlyContin
 
 $___input = ""
 $___expect = 0
-$___output = HestiaKERNEL-Is-Directory-FS $___input
+$___output = HestiaKERNEL-FS-Is-Directory $___input
 $null = Write-Host "Given input  :`n|${___input}|`n"
-$null = Write-Host "Given expect :`n|${___expect}|`n"
+$null = Write-Host "Given expect :`n|not ${___expect}|`n"
 $null = Write-Host "Got Output   :`n|${___output}|`n"
 
 

--- a/Shell/tests/FS/Is_Directory/2.sh
+++ b/Shell/tests/FS/Is_Directory/2.sh
@@ -11,7 +11,7 @@
 # the permissions and limitations set forth in the license.
 1>&2 printf --  "%s\n" "\
 TEST CASE  :
-HestiaKERNEL_Is_Directory
+HestiaKERNEL_FS_Is_Directory
 
 DESCRIPTION:
 Function can operate with empty string.
@@ -41,7 +41,7 @@ fi
 
 1>&2 printf --  "Import function library...\n"
 . "$___target"
-___target="$(type HestiaKERNEL_Is_Directory_FS)"
+___target="$(type HestiaKERNEL_FS_Is_Directory)"
 if [ ! "${___target##*not found}"  = "$___target" ]; then
         1>&2 printf --  "[ FAILED ] error on import!\n"
         exit 1
@@ -56,7 +56,7 @@ ___input=""
 ___expect="0"
 1>&2 printf --  "Given expect           :\n|%s|\n\n" "not $___expect"
 
-___output="$(HestiaKERNEL_Is_Directory_FS "$___input")"
+___output="$(HestiaKERNEL_FS_Is_Directory "$___input")"
 ___process=$?
 1>&2 printf --  "Given output           :\n|%s|\n\n" "$___output"
 1>&2 printf --  "Given exit code        :\n|%s|\n\n" "$___process"

--- a/Shell/tests/FS/Is_Directory/3.ps1
+++ b/Shell/tests/FS/Is_Directory/3.ps1
@@ -11,7 +11,7 @@
 # the permissions and limitations set forth in the license.
 $null = Write-Host @"
 TEST CASE  :
-HestiaKERNEL-Is-Directory
+HestiaKERNEL-FS-Is-Directory
 
 DESCRIPTION:
 Function can operate with invalid path.
@@ -42,7 +42,7 @@ if (-not (Test-Path -Path $___target)) {
 
 $null = Write-Host "Import function library..."
 $null = . $___target
-if (-not (Get-Command 'HestiaKERNEL-Is-Directory-FS' -errorAction SilentlyContinue)) {
+if (-not (Get-Command 'HestiaKERNEL-FS-Is-Directory' -errorAction SilentlyContinue)) {
         $null = Write-Host "[ FAILED ] error on import!`n"
         exit 1
 }
@@ -52,7 +52,7 @@ if (-not (Get-Command 'HestiaKERNEL-Is-Directory-FS' -errorAction SilentlyContin
 
 $___input = "${env:LIBS_HESTIA}\HestiaKERNEL\FS\aregRWEGaegeagaeG"
 $___expect = 0
-$___output = HestiaKERNEL-Is-Directory-FS $___input
+$___output = HestiaKERNEL-FS-Is-Directory $___input
 $null = Write-Host "Given input  :`n|${___input}|`n"
 $null = Write-Host "Given expect :`n|not ${___expect}|`n"
 $null = Write-Host "Got Output   :`n|${___output}|`n"

--- a/Shell/tests/FS/Is_Directory/3.sh
+++ b/Shell/tests/FS/Is_Directory/3.sh
@@ -11,7 +11,7 @@
 # the permissions and limitations set forth in the license.
 1>&2 printf --  "%s\n" "\
 TEST CASE  :
-HestiaKERNEL_Is_Directory
+HestiaKERNEL_FS_Is_Directory
 
 DESCRIPTION:
 Function can operate with invalid path.
@@ -41,7 +41,7 @@ fi
 
 1>&2 printf --  "Import function library...\n"
 . "$___target"
-___target="$(type HestiaKERNEL_Is_Directory_FS)"
+___target="$(type HestiaKERNEL_FS_Is_Directory)"
 if [ ! "${___target##*not found}"  = "$___target" ]; then
         1>&2 printf --  "[ FAILED ] error on import!\n"
         exit 1
@@ -56,7 +56,7 @@ ___input="${LIBS_HESTIA}/HestiaKERNEL/FS/aregRWEGaegeagaeG"
 ___expect="0"
 1>&2 printf --  "Given expect           :\n|%s|\n\n" "not $___expect"
 
-___output="$(HestiaKERNEL_Is_Directory_FS "$___input")"
+___output="$(HestiaKERNEL_FS_Is_Directory "$___input")"
 ___process=$?
 1>&2 printf --  "Given output           :\n|%s|\n\n" "$___output"
 1>&2 printf --  "Given exit code        :\n|%s|\n\n" "$___process"

--- a/Shell/tests/FS/Is_File/0.ps1
+++ b/Shell/tests/FS/Is_File/0.ps1
@@ -11,7 +11,7 @@
 # the permissions and limitations set forth in the license.
 $null = Write-Host @"
 TEST CASE  :
-HestiaKERNEL-Is-File
+HestiaKERNEL-FS-Is-File
 
 DESCRIPTION:
 Function can identify a proper file path.
@@ -42,7 +42,7 @@ if (-not (Test-Path -Path $___target)) {
 
 $null = Write-Host "Import function library..."
 $null = . $___target
-if (-not (Get-Command 'HestiaKERNEL-Is-File-FS' -errorAction SilentlyContinue)) {
+if (-not (Get-Command 'HestiaKERNEL-FS-Is-File' -errorAction SilentlyContinue)) {
         $null = Write-Host "[ FAILED ] error on import!`n"
         exit 1
 }
@@ -52,7 +52,7 @@ if (-not (Get-Command 'HestiaKERNEL-Is-File-FS' -errorAction SilentlyContinue)) 
 
 $___input = "${env:LIBS_HESTIA}\HestiaKERNEL\FS\Is_File.ps1"
 $___expect = 0
-$___output = HestiaKERNEL-Is-File-FS $___input
+$___output = HestiaKERNEL-FS-Is-File $___input
 $null = Write-Host "Given input  :`n|${___input}|`n"
 $null = Write-Host "Given expect :`n|${___expect}|`n"
 $null = Write-Host "Got Output   :`n|${___output}|`n"

--- a/Shell/tests/FS/Is_File/0.sh
+++ b/Shell/tests/FS/Is_File/0.sh
@@ -11,7 +11,7 @@
 # the permissions and limitations set forth in the license.
 1>&2 printf --  "%s\n" "\
 TEST CASE  :
-HestiaKERNEL_Is_File
+HestiaKERNEL_FS_Is_File
 
 DESCRIPTION:
 Function can identify a proper file path.
@@ -41,7 +41,7 @@ fi
 
 1>&2 printf --  "Import function library...\n"
 . "$___target"
-___target="$(type HestiaKERNEL_Is_File_FS)"
+___target="$(type HestiaKERNEL_FS_Is_File)"
 if [ ! "${___target##*not found}"  = "$___target" ]; then
         1>&2 printf --  "[ FAILED ] error on import!\n"
         exit 1
@@ -56,7 +56,7 @@ ___input="${LIBS_HESTIA}/HestiaKERNEL/FS/Is_File.sh"
 ___expect="0"
 1>&2 printf --  "Given expect           :\n|%s|\n\n" "$___expect"
 
-___output="$(HestiaKERNEL_Is_File_FS "$___input")"
+___output="$(HestiaKERNEL_FS_Is_File "$___input")"
 ___process=$?
 1>&2 printf --  "Given output           :\n|%s|\n\n" "$___output"
 1>&2 printf --  "Given exit code        :\n|%s|\n\n" "$___process"

--- a/Shell/tests/FS/Is_File/1.ps1
+++ b/Shell/tests/FS/Is_File/1.ps1
@@ -11,7 +11,7 @@
 # the permissions and limitations set forth in the license.
 $null = Write-Host @"
 TEST CASE  :
-HestiaKERNEL-Is-File
+HestiaKERNEL-FS-Is-File
 
 DESCRIPTION:
 Function can identify a proper directory path.
@@ -42,7 +42,7 @@ if (-not (Test-Path -Path $___target)) {
 
 $null = Write-Host "Import function library..."
 $null = . $___target
-if (-not (Get-Command 'HestiaKERNEL-Is-File-FS' -errorAction SilentlyContinue)) {
+if (-not (Get-Command 'HestiaKERNEL-FS-Is-File' -errorAction SilentlyContinue)) {
         $null = Write-Host "[ FAILED ] error on import!`n"
         exit 1
 }
@@ -52,7 +52,7 @@ if (-not (Get-Command 'HestiaKERNEL-Is-File-FS' -errorAction SilentlyContinue)) 
 
 $___input = "${env:LIBS_HESTIA}\HestiaKERNEL"
 $___expect = 0
-$___output = HestiaKERNEL-Is-File-FS $___input
+$___output = HestiaKERNEL-FS-Is-File $___input
 $null = Write-Host "Given input  :`n|${___input}|`n"
 $null = Write-Host "Given expect :`n|not ${___expect}|`n"
 $null = Write-Host "Got Output   :`n|${___output}|`n"

--- a/Shell/tests/FS/Is_File/1.sh
+++ b/Shell/tests/FS/Is_File/1.sh
@@ -11,7 +11,7 @@
 # the permissions and limitations set forth in the license.
 1>&2 printf --  "%s\n" "\
 TEST CASE  :
-HestiaKERNEL_Is_File
+HestiaKERNEL_FS_Is_File
 
 DESCRIPTION:
 Function can identify a proper directory path.
@@ -41,7 +41,7 @@ fi
 
 1>&2 printf --  "Import function library...\n"
 . "$___target"
-___target="$(type HestiaKERNEL_Is_File_FS)"
+___target="$(type HestiaKERNEL_FS_Is_File)"
 if [ ! "${___target##*not found}"  = "$___target" ]; then
         1>&2 printf --  "[ FAILED ] error on import!\n"
         exit 1
@@ -52,7 +52,7 @@ fi
 
 ___input="${LIBS_HESTIA}/HestiaKERNEL"
 ___expect="0"
-___output="$(HestiaKERNEL_Is_File_FS "$___input")"
+___output="$(HestiaKERNEL_FS_Is_File "$___input")"
 ___process=$?
 1>&2 printf --  "Given input            :\n|%s|\n\n" "$___input"
 1>&2 printf --  "Given expect           :\n|not %s|\n\n" "$___expect"

--- a/Shell/tests/FS/Is_File/2.ps1
+++ b/Shell/tests/FS/Is_File/2.ps1
@@ -11,7 +11,7 @@
 # the permissions and limitations set forth in the license.
 $null = Write-Host @"
 TEST CASE  :
-HestiaKERNEL-Is-File
+HestiaKERNEL-FS-Is-File
 
 DESCRIPTION:
 Function can operate with empty string.
@@ -42,7 +42,7 @@ if (-not (Test-Path -Path $___target)) {
 
 $null = Write-Host "Import function library..."
 $null = . $___target
-if (-not (Get-Command 'HestiaKERNEL-Is-File-FS' -errorAction SilentlyContinue)) {
+if (-not (Get-Command 'HestiaKERNEL-FS-Is-File' -errorAction SilentlyContinue)) {
         $null = Write-Host "[ FAILED ] error on import!`n"
         exit 1
 }
@@ -52,7 +52,7 @@ if (-not (Get-Command 'HestiaKERNEL-Is-File-FS' -errorAction SilentlyContinue)) 
 
 $___input = ""
 $___expect = 0
-$___output = HestiaKERNEL-Is-File-FS $___input
+$___output = HestiaKERNEL-FS-Is-File $___input
 $null = Write-Host "Given input  :`n|${___input}|`n"
 $null = Write-Host "Given expect :`n|not ${___expect}|`n"
 $null = Write-Host "Got Output   :`n|${___output}|`n"

--- a/Shell/tests/FS/Is_File/2.sh
+++ b/Shell/tests/FS/Is_File/2.sh
@@ -11,7 +11,7 @@
 # the permissions and limitations set forth in the license.
 1>&2 printf --  "%s\n" "\
 TEST CASE  :
-HestiaKERNEL_Is_File
+HestiaKERNEL_FS_Is_File
 
 DESCRIPTION:
 Function can operate with empty string.
@@ -41,7 +41,7 @@ fi
 
 1>&2 printf --  "Import function library...\n"
 . "$___target"
-___target="$(type HestiaKERNEL_Is_File_FS)"
+___target="$(type HestiaKERNEL_FS_Is_File)"
 if [ ! "${___target##*not found}"  = "$___target" ]; then
         1>&2 printf --  "[ FAILED ] error on import!\n"
         exit 1
@@ -52,7 +52,7 @@ fi
 
 ___input=""
 ___expect="0"
-___output="$(HestiaKERNEL_Is_File_FS "$___input")"
+___output="$(HestiaKERNEL_FS_Is_File "$___input")"
 ___process=$?
 1>&2 printf --  "Given input            :\n|%s|\n\n" "$___input"
 1>&2 printf --  "Given expect           :\n|not %s|\n\n" "$___expect"

--- a/Shell/tests/FS/Is_File/3.ps1
+++ b/Shell/tests/FS/Is_File/3.ps1
@@ -11,7 +11,7 @@
 # the permissions and limitations set forth in the license.
 $null = Write-Host @"
 TEST CASE  :
-HestiaKERNEL-Is-File
+HestiaKERNEL-FS-Is-File
 
 DESCRIPTION:
 Function can operate with invalid path.
@@ -42,7 +42,7 @@ if (-not (Test-Path -Path $___target)) {
 
 $null = Write-Host "Import function library..."
 $null = . $___target
-if (-not (Get-Command 'HestiaKERNEL-Is-File-FS' -errorAction SilentlyContinue)) {
+if (-not (Get-Command 'HestiaKERNEL-FS-Is-File' -errorAction SilentlyContinue)) {
         $null = Write-Host "[ FAILED ] error on import!`n"
         exit 1
 }
@@ -52,7 +52,7 @@ if (-not (Get-Command 'HestiaKERNEL-Is-File-FS' -errorAction SilentlyContinue)) 
 
 $___input = "${env:LIBS_HESTIA}\HestiaKERNEL\FS\aregRWEGaegeagaeG"
 $___expect = 0
-$___output = HestiaKERNEL-Is-File-FS $___input
+$___output = HestiaKERNEL-FS-Is-File $___input
 $null = Write-Host "Given input  :`n|${___input}|`n"
 $null = Write-Host "Given expect :`n|not ${___expect}|`n"
 $null = Write-Host "Got Output   :`n|${___output}|`n"

--- a/Shell/tests/FS/Is_File/3.sh
+++ b/Shell/tests/FS/Is_File/3.sh
@@ -11,7 +11,7 @@
 # the permissions and limitations set forth in the license.
 1>&2 printf --  "%s\n" "\
 TEST CASE  :
-HestiaKERNEL_Is_File
+HestiaKERNEL_FS_Is_File
 
 DESCRIPTION:
 Function can operate with invalid path.
@@ -41,7 +41,7 @@ fi
 
 1>&2 printf --  "Import function library...\n"
 . "$___target"
-___target="$(type HestiaKERNEL_Is_File_FS)"
+___target="$(type HestiaKERNEL_FS_Is_File)"
 if [ ! "${___target##*not found}"  = "$___target" ]; then
         1>&2 printf --  "[ FAILED ] error on import!\n"
         exit 1
@@ -52,7 +52,7 @@ fi
 
 ___input="${LIBS_HESTIA}/HestiaKERNEL/FS/aregRWEGaegeagaeG"
 ___expect="0"
-___output="$(HestiaKERNEL_Is_File_FS "$___input")"
+___output="$(HestiaKERNEL_FS_Is_File "$___input")"
 ___process=$?
 1>&2 printf --  "Given input            :\n|%s|\n\n" "$___input"
 1>&2 printf --  "Given expect           :\n|not %s|\n\n" "$___expect"


### PR DESCRIPTION
It's better to have the type comes after the library name like 'HestiaKERNEL_ERROR...' or 'HestiaKERNEL_OS...' function names and filepaths. That way, it's less learning yet tracable by reading. Hence, let's deal with all the FS functions.

This patch renames all FS functions to align with new findings in Shell/ directory.