### PR TITLE
Shell: renamed all Number functions to align with new findings

### DIFF
--- a/Shell/libraries/HestiaKERNEL/FS/Get_Files.sh
+++ b/Shell/libraries/HestiaKERNEL/FS/Get_Files.sh
@@ -33,7 +33,7 @@ HestiaKERNEL_FS_Get_Files() {
         # execute
         for ____item in "$1"/*; do
                 if [ $(HestiaKERNEL_FS_Is_Directory "$____item") -eq $HestiaKERNEL_ERROR_OK ]; then
-                        if [ $(HestiaKERNEL_Is_Number "$3") -ne $HestiaKERNEL_ERROR_OK ]; then
+                        if [ $(HestiaKERNEL_NUMBER_Is_Number "$3") -ne $HestiaKERNEL_ERROR_OK ]; then
                                 continue
                         fi
 

--- a/Shell/libraries/HestiaKERNEL/List/Is_Array_Byte.sh
+++ b/Shell/libraries/HestiaKERNEL/List/Is_Array_Byte.sh
@@ -42,7 +42,7 @@ HestiaKERNEL_Is_Array_Byte() {
                         ___content="${___content#, }"
                 fi
 
-                if [ "$(HestiaKERNEL_Is_Number "$___byte")" -ne $HestiaKERNEL_ERROR_OK ]; then
+                if [ $(HestiaKERNEL_NUMBER_Is_Number "$___byte") -ne $HestiaKERNEL_ERROR_OK ]; then
                         printf -- "%d" $HestiaKERNEL_ERROR_DATA_INVALID
                         return $HestiaKERNEL_ERROR_DATA_INVALID
                 fi

--- a/Shell/libraries/HestiaKERNEL/Number/Is_Number.ps1
+++ b/Shell/libraries/HestiaKERNEL/Number/Is_Number.ps1
@@ -14,7 +14,7 @@
 
 
 
-function HestiaKERNEL-Is-Number {
+function HestiaKERNEL-NUMBER-Is-Number {
         param (
                 [object]$___content
         )

--- a/Shell/libraries/HestiaKERNEL/Number/Is_Number.sh
+++ b/Shell/libraries/HestiaKERNEL/Number/Is_Number.sh
@@ -14,7 +14,7 @@
 
 
 
-HestiaKERNEL_Is_Number() {
+HestiaKERNEL_NUMBER_Is_Number() {
         #___input="$1"
 
 

--- a/Shell/libraries/HestiaKERNEL/Unicode/Is_Punctuation_Unicode.ps1
+++ b/Shell/libraries/HestiaKERNEL/Unicode/Is_Punctuation_Unicode.ps1
@@ -21,7 +21,7 @@ function HestiaKERNEL-Is-Punctuation-Unicode {
 
 
         # validate input
-        if ($(HestiaKERNEL-Is-Number $___unicode) -ne ${env:HestiaKERNEL_ERROR_OK}) {
+        if ($(HestiaKERNEL-NUMBER-Is-Number $___unicode) -ne ${env:HestiaKERNEL_ERROR_OK}) {
                 return ${env:HestiaKERNEL_ERROR_DATA_INVALID}
         }
 

--- a/Shell/libraries/HestiaKERNEL/Unicode/Is_Punctuation_Unicode.sh
+++ b/Shell/libraries/HestiaKERNEL/Unicode/Is_Punctuation_Unicode.sh
@@ -20,7 +20,7 @@ HestiaKERNEL_Is_Punctuation_Unicode() {
 
 
         # validate input
-        if [ "$(HestiaKERNEL_Is_Number "$1")" -ne $HestiaKERNEL_ERROR_OK ]; then
+        if [ "$(HestiaKERNEL_NUMBER_Is_Number "$1")" -ne $HestiaKERNEL_ERROR_OK ]; then
                 printf -- "%d" $HestiaKERNEL_ERROR_DATA_INVALID
                 return $HestiaKERNEL_ERROR_DATA_INVALID
         fi

--- a/Shell/libraries/HestiaKERNEL/Unicode/Replace_Any_Left_Unicode.ps1
+++ b/Shell/libraries/HestiaKERNEL/Unicode/Replace_Any_Left_Unicode.ps1
@@ -10,7 +10,6 @@
 # the permissions and limitations set forth in the license.
 . "${env:LIBS_HESTIA}\HestiaKERNEL\Error\Codes.ps1"
 . "${env:LIBS_HESTIA}\HestiaKERNEL\Unicode\Is_Unicode.ps1"
-. "${env:LIBS_HESTIA}\HestiaKERNEL\Number\Is_Number.ps1"
 
 
 

--- a/Shell/libraries/HestiaKERNEL/Unicode/Replace_Any_Left_Unicode.sh
+++ b/Shell/libraries/HestiaKERNEL/Unicode/Replace_Any_Left_Unicode.sh
@@ -43,12 +43,12 @@ HestiaKERNEL_Replace_Any_Left_Unicode() {
         fi
 
         ___count=-1
-        if [ $(HestiaKERNEL_Is_Number "$4") -eq $HestiaKERNEL_ERROR_OK ]; then
+        if [ $(HestiaKERNEL_NUMBER_Is_Number "$4") -eq $HestiaKERNEL_ERROR_OK ]; then
                 ___count="$4"
         fi
 
         ___ignore=-1
-        if [ $(HestiaKERNEL_Is_Number "$5") -eq $HestiaKERNEL_ERROR_OK ]; then
+        if [ $(HestiaKERNEL_NUMBER_Is_Number "$5") -eq $HestiaKERNEL_ERROR_OK ]; then
                 ___ignore="$5"
         fi
 

--- a/Shell/libraries/HestiaKERNEL/Unicode/Replace_Any_Right_Unicode.ps1
+++ b/Shell/libraries/HestiaKERNEL/Unicode/Replace_Any_Right_Unicode.ps1
@@ -10,7 +10,6 @@
 # the permissions and limitations set forth in the license.
 . "${env:LIBS_HESTIA}\HestiaKERNEL\Error\Codes.ps1"
 . "${env:LIBS_HESTIA}\HestiaKERNEL\Unicode\Is_Unicode.ps1"
-. "${env:LIBS_HESTIA}\HestiaKERNEL\Number\Is_Number.ps1"
 
 
 

--- a/Shell/libraries/HestiaKERNEL/Unicode/Replace_Any_Right_Unicode.sh
+++ b/Shell/libraries/HestiaKERNEL/Unicode/Replace_Any_Right_Unicode.sh
@@ -42,12 +42,12 @@ HestiaKERNEL_Replace_Any_Right_Unicode() {
         fi
 
         ___count=-1
-        if [ "$(HestiaKERNEL_Is_Number "$4")" -eq $HestiaKERNEL_ERROR_OK ]; then
+        if [ "$(HestiaKERNEL_NUMBER_Is_Number "$4")" -eq $HestiaKERNEL_ERROR_OK ]; then
                 ___count="$4"
         fi
 
         ___ignore=-1
-        if [ "$(HestiaKERNEL_Is_Number "$5")" -eq $HestiaKERNEL_ERROR_OK ]; then
+        if [ "$(HestiaKERNEL_NUMBER_Is_Number "$5")" -eq $HestiaKERNEL_ERROR_OK ]; then
                 ___ignore="$5"
         fi
 

--- a/Shell/libraries/HestiaKERNEL/Unicode/Replace_Left_Unicode.ps1
+++ b/Shell/libraries/HestiaKERNEL/Unicode/Replace_Left_Unicode.ps1
@@ -10,7 +10,6 @@
 # the permissions and limitations set forth in the license.
 . "${env:LIBS_HESTIA}\HestiaKERNEL\Error\Codes.ps1"
 . "${env:LIBS_HESTIA}\HestiaKERNEL\Unicode\Is_Unicode.ps1"
-. "${env:LIBS_HESTIA}\HestiaKERNEL\Number\Is_Number.ps1"
 
 
 

--- a/Shell/libraries/HestiaKERNEL/Unicode/Replace_Left_Unicode.sh
+++ b/Shell/libraries/HestiaKERNEL/Unicode/Replace_Left_Unicode.sh
@@ -43,12 +43,12 @@ HestiaKERNEL_Replace_Left_Unicode() {
         fi
 
         ___count=-1
-        if [ $(HestiaKERNEL_Is_Number "$4") -eq $HestiaKERNEL_ERROR_OK ]; then
+        if [ $(HestiaKERNEL_NUMBER_Is_Number "$4") -eq $HestiaKERNEL_ERROR_OK ]; then
                 ___count="$4"
         fi
 
         ___ignore=-1
-        if [ $(HestiaKERNEL_Is_Number "$5") -eq $HestiaKERNEL_ERROR_OK ]; then
+        if [ $(HestiaKERNEL_NUMBER_Is_Number "$5") -eq $HestiaKERNEL_ERROR_OK ]; then
                 ___ignore="$5"
         fi
 

--- a/Shell/libraries/HestiaKERNEL/Unicode/Replace_Right_Unicode.ps1
+++ b/Shell/libraries/HestiaKERNEL/Unicode/Replace_Right_Unicode.ps1
@@ -10,7 +10,6 @@
 # the permissions and limitations set forth in the license.
 . "${env:LIBS_HESTIA}\HestiaKERNEL\Error\Codes.ps1"
 . "${env:LIBS_HESTIA}\HestiaKERNEL\Unicode\Is_Unicode.ps1"
-. "${env:LIBS_HESTIA}\HestiaKERNEL\Number\Is_Number.ps1"
 
 
 

--- a/Shell/libraries/HestiaKERNEL/Unicode/Replace_Right_Unicode.sh
+++ b/Shell/libraries/HestiaKERNEL/Unicode/Replace_Right_Unicode.sh
@@ -42,12 +42,12 @@ HestiaKERNEL_Replace_Right_Unicode() {
         fi
 
         ___count=-1
-        if [ "$(HestiaKERNEL_Is_Number "$4")" -eq $HestiaKERNEL_ERROR_OK ]; then
+        if [ "$(HestiaKERNEL_NUMBER_Is_Number "$4")" -eq $HestiaKERNEL_ERROR_OK ]; then
                 ___count="$4"
         fi
 
         ___ignore=-1
-        if [ "$(HestiaKERNEL_Is_Number "$5")" -eq $HestiaKERNEL_ERROR_OK ]; then
+        if [ "$(HestiaKERNEL_NUMBER_Is_Number "$5")" -eq $HestiaKERNEL_ERROR_OK ]; then
                 ___ignore="$5"
         fi
 

--- a/Shell/libraries/HestiaKERNEL/Unicode/Scan_Any_Left_Unicode.ps1
+++ b/Shell/libraries/HestiaKERNEL/Unicode/Scan_Any_Left_Unicode.ps1
@@ -9,7 +9,6 @@
 # You MUST ensure any interaction with the content STRICTLY COMPLIES with
 # the permissions and limitations set forth in the license.
 . "${env:LIBS_HESTIA}\HestiaKERNEL\Unicode\Is_Unicode.ps1"
-. "${env:LIBS_HESTIA}\HestiaKERNEL\Number\Is_Number.ps1"
 
 
 

--- a/Shell/libraries/HestiaKERNEL/Unicode/Scan_Any_Left_Unicode.sh
+++ b/Shell/libraries/HestiaKERNEL/Unicode/Scan_Any_Left_Unicode.sh
@@ -36,12 +36,12 @@ HestiaKERNEL_Scan_Any_Left_Unicode() {
         fi
 
         ___count=-1
-        if [ $(HestiaKERNEL_Is_Number "$3") -eq $HestiaKERNEL_ERROR_OK ]; then
+        if [ $(HestiaKERNEL_NUMBER_Is_Number "$3") -eq $HestiaKERNEL_ERROR_OK ]; then
                 ___count="$3"
         fi
 
         ___ignore=-1
-        if [ $(HestiaKERNEL_Is_Number "$4") -eq $HestiaKERNEL_ERROR_OK ]; then
+        if [ $(HestiaKERNEL_NUMBER_Is_Number "$4") -eq $HestiaKERNEL_ERROR_OK ]; then
                 ___ignore="$4"
         fi
 

--- a/Shell/libraries/HestiaKERNEL/Unicode/Scan_Any_Right_Unicode.ps1
+++ b/Shell/libraries/HestiaKERNEL/Unicode/Scan_Any_Right_Unicode.ps1
@@ -9,7 +9,6 @@
 # You MUST ensure any interaction with the content STRICTLY COMPLIES with
 # the permissions and limitations set forth in the license.
 . "${env:LIBS_HESTIA}\HestiaKERNEL\Unicode\Is_Unicode.ps1"
-. "${env:LIBS_HESTIA}\HestiaKERNEL\Number\Is_Number.ps1"
 
 
 

--- a/Shell/libraries/HestiaKERNEL/Unicode/Scan_Any_Right_Unicode.sh
+++ b/Shell/libraries/HestiaKERNEL/Unicode/Scan_Any_Right_Unicode.sh
@@ -35,12 +35,12 @@ HestiaKERNEL_Scan_Any_Right_Unicode() {
         fi
 
         ___count=-1
-        if [ "$(HestiaKERNEL_Is_Number "$3")" -eq $HestiaKERNEL_ERROR_OK ]; then
+        if [ "$(HestiaKERNEL_NUMBER_Is_Number "$3")" -eq $HestiaKERNEL_ERROR_OK ]; then
                 ___count="$3"
         fi
 
         ___ignore=-1
-        if [ "$(HestiaKERNEL_Is_Number "$4")" -eq $HestiaKERNEL_ERROR_OK ]; then
+        if [ "$(HestiaKERNEL_NUMBER_Is_Number "$4")" -eq $HestiaKERNEL_ERROR_OK ]; then
                 ___ignore="$4"
         fi
 

--- a/Shell/libraries/HestiaKERNEL/Unicode/Scan_Left_Unicode.ps1
+++ b/Shell/libraries/HestiaKERNEL/Unicode/Scan_Left_Unicode.ps1
@@ -9,7 +9,6 @@
 # You MUST ensure any interaction with the content STRICTLY COMPLIES with
 # the permissions and limitations set forth in the license.
 . "${env:LIBS_HESTIA}\HestiaKERNEL\Unicode\Is_Unicode.ps1"
-. "${env:LIBS_HESTIA}\HestiaKERNEL\Number\Is_Number.ps1"
 
 
 

--- a/Shell/libraries/HestiaKERNEL/Unicode/Scan_Left_Unicode.sh
+++ b/Shell/libraries/HestiaKERNEL/Unicode/Scan_Left_Unicode.sh
@@ -36,12 +36,12 @@ HestiaKERNEL_Scan_Left_Unicode() {
         fi
 
         ___count=-1
-        if [ $(HestiaKERNEL_Is_Number "$3") -eq $HestiaKERNEL_ERROR_OK ]; then
+        if [ $(HestiaKERNEL_NUMBER_Is_Number "$3") -eq $HestiaKERNEL_ERROR_OK ]; then
                 ___count="$3"
         fi
 
         ___ignore=-1
-        if [ $(HestiaKERNEL_Is_Number "$4") -eq $HestiaKERNEL_ERROR_OK ]; then
+        if [ $(HestiaKERNEL_NUMBER_Is_Number "$4") -eq $HestiaKERNEL_ERROR_OK ]; then
                 ___ignore="$4"
         fi
 

--- a/Shell/libraries/HestiaKERNEL/Unicode/Scan_Right_Unicode.ps1
+++ b/Shell/libraries/HestiaKERNEL/Unicode/Scan_Right_Unicode.ps1
@@ -9,7 +9,6 @@
 # You MUST ensure any interaction with the content STRICTLY COMPLIES with
 # the permissions and limitations set forth in the license.
 . "${env:LIBS_HESTIA}\HestiaKERNEL\Unicode\Is_Unicode.ps1"
-. "${env:LIBS_HESTIA}\HestiaKERNEL\Number\Is_Number.ps1"
 
 
 

--- a/Shell/libraries/HestiaKERNEL/Unicode/Scan_Right_Unicode.sh
+++ b/Shell/libraries/HestiaKERNEL/Unicode/Scan_Right_Unicode.sh
@@ -35,12 +35,12 @@ HestiaKERNEL_Scan_Right_Unicode() {
         fi
 
         ___count=-1
-        if [ "$(HestiaKERNEL_Is_Number "$3")" -eq $HestiaKERNEL_ERROR_OK ]; then
+        if [ "$(HestiaKERNEL_NUMBER_Is_Number "$3")" -eq $HestiaKERNEL_ERROR_OK ]; then
                 ___count="$3"
         fi
 
         ___ignore=-1
-        if [ "$(HestiaKERNEL_Is_Number "$4")" -eq $HestiaKERNEL_ERROR_OK ]; then
+        if [ "$(HestiaKERNEL_NUMBER_Is_Number "$4")" -eq $HestiaKERNEL_ERROR_OK ]; then
                 ___ignore="$4"
         fi
 

--- a/Shell/libraries/HestiaKERNEL/Unicode/Split_Left_Unicode.ps1
+++ b/Shell/libraries/HestiaKERNEL/Unicode/Split_Left_Unicode.ps1
@@ -10,7 +10,6 @@
 # the permissions and limitations set forth in the license.
 . "${env:LIBS_HESTIA}\HestiaKERNEL\Error\Codes.ps1"
 . "${env:LIBS_HESTIA}\HestiaKERNEL\Unicode\Is_Unicode.ps1"
-. "${env:LIBS_HESTIA}\HestiaKERNEL\Number\Is_Number.ps1"
 
 
 

--- a/Shell/libraries/HestiaKERNEL/Unicode/Split_Left_Unicode.sh
+++ b/Shell/libraries/HestiaKERNEL/Unicode/Split_Left_Unicode.sh
@@ -35,12 +35,12 @@ HestiaKERNEL_Split_Left_Unicode() {
         fi
 
         ___count=-1
-        if [ $(HestiaKERNEL_Is_Number "$3") -eq $HestiaKERNEL_ERROR_OK ]; then
+        if [ $(HestiaKERNEL_NUMBER_Is_Number "$3") -eq $HestiaKERNEL_ERROR_OK ]; then
                 ___count="$4"
         fi
 
         ___ignore=-1
-        if [ $(HestiaKERNEL_Is_Number "$4") -eq $HestiaKERNEL_ERROR_OK ]; then
+        if [ $(HestiaKERNEL_NUMBER_Is_Number "$4") -eq $HestiaKERNEL_ERROR_OK ]; then
                 ___ignore="$5"
         fi
 


### PR DESCRIPTION
It's better to have the type comes after the library name like 'HestiaKERNEL_ERROR...' or 'HestiaKERNEL_OS...' function names and filepaths. That way, it's less learning yet tracable by reading. Hence, let's deal with all the Number functions.

This patch renames all Number functions to align with new findings in Shell/ directory.