### PR TITLE
Shell: renamed all Number functions to align with new findings

### DIFF
--- a/Shell/libraries/HestiaKERNEL/List/Is_Array_Byte.ps1
+++ b/Shell/libraries/HestiaKERNEL/List/Is_Array_Byte.ps1
@@ -14,7 +14,7 @@
 
 
 
-function HestiaKERNEL-Is-Array-Byte {
+function HestiaKERNEL-LIST-Is-Array-Byte {
         param (
                 [byte[]]$___content
         )
@@ -25,7 +25,7 @@ function HestiaKERNEL-Is-Array-Byte {
                 return ${env:HestiaKERNEL_ERROR_DATA_EMPTY}
         }
 
-        if ($(HestiaKERNEL-Is-Array-Number $___content) -ne ${env:HestiaKERNEL_ERROR_OK}) {
+        if ($(HestiaKERNEL-LIST-Is-Array-Number $___content) -ne ${env:HestiaKERNEL_ERROR_OK}) {
                 return ${env:HestiaKERNEL_ERROR_DATA_INVALID}
         }
 

--- a/Shell/libraries/HestiaKERNEL/List/Is_Array_Byte.sh
+++ b/Shell/libraries/HestiaKERNEL/List/Is_Array_Byte.sh
@@ -16,7 +16,7 @@
 
 
 
-HestiaKERNEL_Is_Array_Byte() {
+HestiaKERNEL_LIST_Is_Array_Byte() {
         #___input="$1"
 
 
@@ -26,7 +26,7 @@ HestiaKERNEL_Is_Array_Byte() {
                 return $HestiaKERNEL_ERROR_DATA_EMPTY
         fi
 
-        if [ "$(HestiaKERNEL_Is_Array_Number "$1")" -ne $HestiaKERNEL_ERROR_OK ]; then
+        if [ "$(HestiaKERNEL_LIST_Is_Array_Number "$1")" -ne $HestiaKERNEL_ERROR_OK ]; then
                 printf -- "%d" $HestiaKERNEL_ERROR_DATA_INVALID
                 return $HestiaKERNEL_ERROR_DATA_INVALID
         fi

--- a/Shell/libraries/HestiaKERNEL/List/Is_Array_Number.ps1
+++ b/Shell/libraries/HestiaKERNEL/List/Is_Array_Number.ps1
@@ -14,7 +14,7 @@
 
 
 
-function HestiaKERNEL-Is-Array-Number {
+function HestiaKERNEL-LIST-Is-Array-Number {
         param (
                 [object]$___content
         )

--- a/Shell/libraries/HestiaKERNEL/List/Is_Array_Number.sh
+++ b/Shell/libraries/HestiaKERNEL/List/Is_Array_Number.sh
@@ -14,7 +14,7 @@
 
 
 
-HestiaKERNEL_Is_Array_Number() {
+HestiaKERNEL_LIST_Is_Array_Number() {
         #___input="$1"
 
 

--- a/Shell/libraries/HestiaKERNEL/Unicode/Is_Unicode.ps1
+++ b/Shell/libraries/HestiaKERNEL/Unicode/Is_Unicode.ps1
@@ -27,7 +27,7 @@ function HestiaKERNEL-Is-Unicode {
 
 
         # execute
-        if ($(HestiaKERNEL-Is-Array-Number $___content) -ne ${env:HestiaKERNEL_ERROR_OK}) {
+        if ($(HestiaKERNEL-LIST-Is-Array-Number $___content) -ne ${env:HestiaKERNEL_ERROR_OK}) {
                 return ${env:HestiaKERNEL_ERROR_DATA_INVALID}
         }
 

--- a/Shell/libraries/HestiaKERNEL/Unicode/Is_Unicode.sh
+++ b/Shell/libraries/HestiaKERNEL/Unicode/Is_Unicode.sh
@@ -27,7 +27,7 @@ HestiaKERNEL_Is_Unicode() {
 
 
         # execute
-        if [ $(HestiaKERNEL_Is_Array_Number "$1") -ne $HestiaKERNEL_ERROR_OK ]; then
+        if [ $(HestiaKERNEL_LIST_Is_Array_Number "$1") -ne $HestiaKERNEL_ERROR_OK ]; then
                 printf -- "%d" $HestiaKERNEL_ERROR_DATA_INVALID
                 return $HestiaKERNEL_ERROR_DATA_INVALID
         fi

--- a/Shell/libraries/HestiaKERNEL/Unicode/To_Unicode_From_UTF16.ps1
+++ b/Shell/libraries/HestiaKERNEL/Unicode/To_Unicode_From_UTF16.ps1
@@ -28,7 +28,7 @@ function HestiaKERNEL-To-Unicode-From-UTF16 {
                 return [uint32[]]@()
         }
 
-        if ($(HestiaKERNEL-Is-Array-Byte $___input_content) -ne ${env:HestiaKERNEL_ERROR_OK}) {
+        if ($(HestiaKERNEL-LIST-Is-Array-Byte $___input_content) -ne ${env:HestiaKERNEL_ERROR_OK}) {
                 return [uint32[]]@()
         }
 

--- a/Shell/libraries/HestiaKERNEL/Unicode/To_Unicode_From_UTF16.sh
+++ b/Shell/libraries/HestiaKERNEL/Unicode/To_Unicode_From_UTF16.sh
@@ -29,7 +29,7 @@ HestiaKERNEL_To_Unicode_From_UTF16() {
                 return $HestiaKERNEL_ERROR_DATA_EMPTY
         fi
 
-        if [ "$(HestiaKERNEL_Is_Array_Byte "$1")" -ne $HestiaKERNEL_ERROR_OK ]; then
+        if [ "$(HestiaKERNEL_LIST_Is_Array_Byte "$1")" -ne $HestiaKERNEL_ERROR_OK ]; then
                 printf -- ""
                 return $HestiaKERNEL_ERROR_DATA_INVALID
         fi

--- a/Shell/libraries/HestiaKERNEL/Unicode/To_Unicode_From_UTF32.ps1
+++ b/Shell/libraries/HestiaKERNEL/Unicode/To_Unicode_From_UTF32.ps1
@@ -28,7 +28,7 @@ function HestiaKERNEL-To-Unicode-From-UTF32 {
                 return [uint32[]]@()
         }
 
-        if ($(HestiaKERNEL-Is-Array-Byte $___input_content) -ne ${env:HestiaKERNEL_ERROR_OK}) {
+        if ($(HestiaKERNEL-LIST-Is-Array-Byte $___input_content) -ne ${env:HestiaKERNEL_ERROR_OK}) {
                 return [uint32[]]@()
         }
 

--- a/Shell/libraries/HestiaKERNEL/Unicode/To_Unicode_From_UTF32.sh
+++ b/Shell/libraries/HestiaKERNEL/Unicode/To_Unicode_From_UTF32.sh
@@ -29,7 +29,7 @@ HestiaKERNEL_To_Unicode_From_UTF32() {
                 return $HestiaKERNEL_ERROR_DATA_EMPTY
         fi
 
-        if [ $(HestiaKERNEL_Is_Array_Byte "$1") -ne $HestiaKERNEL_ERROR_OK ]; then
+        if [ $(HestiaKERNEL_List_Is_Array_Byte "$1") -ne $HestiaKERNEL_ERROR_OK ]; then
                 printf -- ""
                 return $HestiaKERNEL_ERROR_DATA_INVALID
         fi

--- a/Shell/libraries/HestiaKERNEL/Unicode/To_Unicode_From_UTF8.ps1
+++ b/Shell/libraries/HestiaKERNEL/Unicode/To_Unicode_From_UTF8.ps1
@@ -26,7 +26,7 @@ function HestiaKERNEL-To-Unicode-From-UTF8 {
                 return [uint32[]]@()
         }
 
-        if ($(HestiaKERNEL-Is-Array-Byte $___input_content) -ne ${env:HestiaKERNEL_ERROR_OK}) {
+        if ($(HestiaKERNEL-LIST-Is-Array-Byte $___input_content) -ne ${env:HestiaKERNEL_ERROR_OK}) {
                 return [uint32[]]@()
         }
 

--- a/Shell/libraries/HestiaKERNEL/Unicode/To_Unicode_From_UTF8.sh
+++ b/Shell/libraries/HestiaKERNEL/Unicode/To_Unicode_From_UTF8.sh
@@ -28,7 +28,7 @@ HestiaKERNEL_To_Unicode_From_UTF8() {
                 return $HestiaKERNEL_ERROR_DATA_EMPTY
         fi
 
-        if [ "$(HestiaKERNEL_Is_Array_Byte "$1")" -ne $HestiaKERNEL_ERROR_OK ]; then
+        if [ "$(HestiaKERNEL_LIST_Is_Array_Byte "$1")" -ne $HestiaKERNEL_ERROR_OK ]; then
                 printf -- ""
                 return $HestiaKERNEL_ERROR_DATA_INVALID
         fi


### PR DESCRIPTION
It's better to have the type comes after the library name like 'HestiaKERNEL_ERROR...' or 'HestiaKERNEL_OS...' function names and filepaths. That way, it's less learning yet tracable by reading. Hence, let's deal with all the Number functions.

This patch renames all Number functions to align with new findings in Shell/ directory.